### PR TITLE
Pass user_data argument to free_cb_function registered with MPI_T_event_handle_free function

### DIFF
--- a/ompi/mpi/tool/event_handle_free.c
+++ b/ompi/mpi/tool/event_handle_free.c
@@ -6,6 +6,8 @@
  * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * Copyright (c) 2018-2019 Triad National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2024      High Performance Computing Center Stuttgart,                                                  
+ *                         University of Stuttgart.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -40,7 +42,7 @@ int MPI_T_event_handle_free (MPI_T_event_registration event_registration,
     if (MPI_T_EVENT_REGISTRATION_NULL == event_registration) {
         ret = MPI_T_ERR_INVALID_HANDLE;
     } else {
-        mca_base_event_registration_free (event_registration, 
+        mca_base_event_registration_free (event_registration, user_data,
                                           (mca_base_event_registration_free_cb_fn_t) free_cb_function);
     }
 

--- a/opal/mca/base/mca_base_event.c
+++ b/opal/mca/base/mca_base_event.c
@@ -10,6 +10,8 @@
  * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * Copyright (c) 2018-2019 Triad National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2024      High Performance Computing Center Stuttgart,                                                  
+ *                         University of Stuttgart.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -416,8 +418,9 @@ int mca_base_event_callback_get_info (mca_base_event_registration_t *registratio
     return OPAL_SUCCESS;
 }
 
-void mca_base_event_registration_free (mca_base_event_registration_t *registration, mca_base_event_registration_free_cb_fn_t cbfn)
+void mca_base_event_registration_free (mca_base_event_registration_t *registration, void *user_data, mca_base_event_registration_free_cb_fn_t cbfn)
 {
+    registration->user_data[MCA_BASE_CB_REQUIRE_NONE] = user_data;
     registration->free_cb = cbfn;
     OBJ_RELEASE(registration);
 }
@@ -577,7 +580,7 @@ static void mca_base_event_registration_destructor (mca_base_event_registration_
     }
 
     if (registration->free_cb) {
-        registration->free_cb (registration, MCA_BASE_CB_REQUIRE_NONE, registration->user_data);
+        registration->free_cb (registration, MCA_BASE_CB_REQUIRE_NONE, registration->user_data[MCA_BASE_CB_REQUIRE_NONE]);
     }
 }
 

--- a/opal/mca/base/mca_base_event.h
+++ b/opal/mca/base/mca_base_event.h
@@ -4,6 +4,8 @@
  *                         reserved.
  * Copyright (c) 2018-2019 Triad National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2024      High Performance Computing Center Stuttgart,                                                  
+ *                         University of Stuttgart.  All rights reserved.
  *
  * Additional copyrights may follow
  *
@@ -198,7 +200,7 @@ OPAL_DECLSPEC int mca_base_event_registration_alloc (mca_base_event_t *event, vo
 OPAL_DECLSPEC int mca_base_event_register_callback (mca_base_event_registration_t *registration, mca_base_cb_safety_t cb_safety,
                                                     opal_info_t *info, void *user_data, mca_base_event_cb_fn_t event_cbfn);
 
-OPAL_DECLSPEC void mca_base_event_registration_free (mca_base_event_registration_t *registration, mca_base_event_registration_free_cb_fn_t cbfn);
+OPAL_DECLSPEC void mca_base_event_registration_free (mca_base_event_registration_t *registration, void *user_data, mca_base_event_registration_free_cb_fn_t cbfn);
 
 OPAL_DECLSPEC void mca_base_event_registration_set_dropped_handler (mca_base_event_registration_t *registration, mca_base_event_dropped_cb_fn_t cbfn);
 


### PR DESCRIPTION
Commit https://github.com/open-mpi/ompi/commit/9350bee1af90c1861ff000ee8400c57e43dec6da introduces the user-data argument in `MPI_T_event_handle_free()` function. But it does not pass it along further while calling `mca_base_event_registration_free()`. Consequently, `mca_base_event_registration_destructor()` passes the r`egistration->user_data` member directly making it not readily available in the callback. This commit should fix it.